### PR TITLE
Provide an example to Custom CSS, rename Slides

### DIFF
--- a/user_guide/apps/slides.rst
+++ b/user_guide/apps/slides.rst
@@ -1,10 +1,10 @@
 
 .. _app_slides:
 
-Slides
-======
+Presentation (Slides)
+=====================
 
-The Slides application in CryptPad is an integration of
+The Presentation (Slides) application in CryptPad is an integration of
 `CodeMirror <https://codemirror.net/>`__.
 
 .. image:: /images/app-slides-preview.png
@@ -60,6 +60,19 @@ Theme
 colors for the presentation.
 
 **Theme**: Color scheme used in the code editor pane.
+
+Example *Custom CSS*
+~~~~~~~~~~~~~~~~~~~~
+
+This example shows using an external font and some (very visible) changes. You can only reference *locally served* files due to security reasons, usually provided by the local admin under the ``/customize/`` directory. 
+
+.. code:: css
+
+ @font-face { font-family: NeuroPolitical; src: url('/customize/fonts/neuropolitical.ttf'); }
+ *  { font-family: NeuroPolitical; }
+ p  { background: #aaf; }
+ ul { background: yellow; }
+
 
 Import/Export
 -------------


### PR DESCRIPTION
- example for Custom CSS changing color and using a custom font (issue #760)
- Slides seem to have been renamed to Presentation now, first section helps the user to know that s/he's in the right place