### PR TITLE
Move warning message for history deletion

### DIFF
--- a/user_guide/apps/general.rst
+++ b/user_guide/apps/general.rst
@@ -148,10 +148,6 @@ To delete a snapshot:
 - |file-o| **File** > |camera| **Snapshots**
 - In the dialog, ``Click`` on the snapshot in the list and |trash| **Delete**.
 
-.. warning::
-   Snapshots are part of the document's history. If you delete the history in the :ref:`document_properties`
-   snapshots will be deleted as well.
-
 .. _document_properties:
 
 Properties
@@ -175,6 +171,10 @@ Available data:
 -  Size.
 
 The document size shows the proportions used for content and for history. To save storage space, delete the document’s history with **Delete history** and confirm. :badge_owner:`Document owners`
+
+.. warning::
+   :ref:`snapshots` are part of the document's history. If you delete the history in the document's properties
+   snapshots will be deleted as well.
 
 .. _document_users_and_chat:
 


### PR DESCRIPTION
This PR intends to move the warning message that deleting history also removes snapshots to the place right after explanation of history deletion, since the message is about deleting the history causing unexpected results and it should be noticed by the users who are removing history from a large document (which is likely to have multiple snapshots) but do not realize that removing history also removes the snapshots unexpectedly for them.

Before:

![before](https://github.com/user-attachments/assets/271611ef-392f-447b-847c-dddb9dedc580)

After:

![after](https://github.com/user-attachments/assets/39ee8772-8b8e-4625-88aa-192cc2f5c770)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>