### PR TITLE
Use shallow clone to save admins bandwidth and storage

### DIFF
--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -60,7 +60,7 @@ Clone the CryptPad repository
 
 .. code:: bash
 
-   git clone https://github.com/cryptpad/cryptpad.git cryptpad
+   git clone -b 2024.12.0 --depth 1 https://github.com/cryptpad/cryptpad.git cryptpad
 
 Move to the newly cloned repository
 
@@ -72,7 +72,7 @@ Switch to the latest published tag
 
 .. code:: bash
 
-   git checkout 2024.6.1
+   git checkout 2024.12.0
 
 Dependencies
 """"""""""""


### PR DESCRIPTION
Because only core devs ever need every version of every file in the repo’s full history, this PR lets admins use a shallow clone and thereby save considerable bandwidth and storage.

On an OnlyOffice-included instance, the difference is 2.5G vs 2.9G.