### PR TITLE
Ensure correct permissions for subdirectories

### DIFF
--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -204,7 +204,7 @@ We provide the following files in the CryptPad repository:
 
    .. code:: bash
 
-      mkdir -p data customize onlyoffice-dist onlyoffice-conf
+      mkdir -p data/{blob,block,data,files} customize onlyoffice-dist onlyoffice-conf
       sudo chown -R 4001:4001 data customize onlyoffice-dist onlyoffice-conf
 
 #. Run the container with Docker Compose


### PR DESCRIPTION
This PR updates the documentation to prevent errors like this on the first container start:

```
cryptpad-1  | [Error: EACCES: permission denied, mkdir '/cryptpad/data/logs'] {
cryptpad-1  |   errno: -13,
cryptpad-1  |   code: 'EACCES',
cryptpad-1  |   syscall: 'mkdir',
cryptpad-1  |   path: '/cryptpad/data/logs'
cryptpad-1  | }
```

---

If not created beforehand, `docker compose up` creates these missing subdirectories (on the first start): `data/{blob,block,data,files}`. They are then (most likely) not owned by the user with the ID 4001.