### PR TITLE
Translations update from CryptPad Translations

### DIFF
--- a/locale/zh_Hant/LC_MESSAGES/user_guide/drive.po
+++ b/locale/zh_Hant/LC_MESSAGES/user_guide/drive.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CryptPad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-05-18 16:39+0100\n"
-"PO-Revision-Date: 2026-05-19 14:52+0000\n"
+"PO-Revision-Date: 2026-05-19 15:30+0000\n"
 "Last-Translator: David Benqué <david.benque@xwiki.com>\n"
 "Language-Team: Chinese (Traditional Han script) <https://"
 "weblate.cryptpad.org/projects/user-guide/drive/zh_Hant/>\n"
@@ -93,9 +93,8 @@ msgid "|plus| **New** in the toolbar > |folder| **Folder**."
 msgstr "工具列中的 |plus| **新增** > |folder| **資料夾**。"
 
 #: ../../user_guide/drive.rst:43
-#, fuzzy
 msgid "``Right click`` > |folder| **New folder**."
-msgstr "按滑鼠右鍵 > |folder| **新增資料夾**。"
+msgstr "``按滑鼠右鍵`` > |folder| **新增資料夾**。"
 
 #: ../../user_guide/drive.rst:44
 msgid ":kbd:`Ctrl + e` > |folder| **Folder**."
@@ -118,20 +117,19 @@ msgstr "若要變更資料夾顏色："
 #: ../../user_guide/drive.rst:50
 #, fuzzy
 msgid "``Right click`` on the folder > |cptools palette| **Change color**."
-msgstr "在資料夾上按滑鼠右鍵 > |cptools palette| **變更顏色**。"
+msgstr "在資料夾上 ``按滑鼠右鍵`` > |cptools palette| **變更顏色**。"
 
 #: ../../user_guide/drive.rst:52
 msgid "To share a folder and all of its contents:"
 msgstr "若要分享資料夾及其所有內容："
 
 #: ../../user_guide/drive.rst:54
-#, fuzzy
 msgid ""
 "``Right click`` on the folder > |share-alt| **Share**. The folder will "
 "then be converted into a :ref:`shared folder <shared_folders>`."
 msgstr ""
-"在資料夾上按滑鼠右鍵 > |share-alt| **分享**。該資料夾會轉為 :ref:`共用資料夾 "
-"<shared_folders>`。"
+"在資料夾上 ``按滑鼠右鍵`` > |share-alt| **分享**。該資料夾會轉為 :ref:`共用資"
+"料夾 <shared_folders>`。"
 
 #: ../../user_guide/drive.rst:57
 msgid "Renaming"
@@ -171,9 +169,8 @@ msgid "To change the title of a document only in your drive:"
 msgstr "若只變更您雲端硬碟中的文件顯示名稱："
 
 #: ../../user_guide/drive.rst:69
-#, fuzzy
 msgid "``Right click`` on the document in your drive > |pencil| **Rename**."
-msgstr "在雲端硬碟中的文件上按滑鼠右鍵 > |pencil| **重新命名**。"
+msgstr "在雲端硬碟中的文件上 ``按滑鼠右鍵`` > |pencil| **重新命名**。"
 
 #: ../../user_guide/drive.rst:70
 msgid "Type the new name."
@@ -210,7 +207,6 @@ msgstr ""
 "碟中還原。"
 
 #: ../../user_guide/drive.rst:83
-#, fuzzy
 msgid ""
 "|cptools destroy| **Destroying** a document deletes it from the database "
 "permanently. The document is deleted from all drives that store it, and "
@@ -221,13 +217,12 @@ msgstr ""
 "硬碟中刪除，且無法透過雲端硬碟歷程還原。:badge_owner:`文件擁有者`"
 
 #: ../../user_guide/drive.rst:87
-#, fuzzy
 msgid ""
 "If a document is not stored in any drive, it is **destroyed** from the "
 "database after 90 days (the length of this delay can be set by the "
 "service administrators)."
 msgstr ""
-"若文件未儲存在任何雲端硬碟中，90 天後會從資料庫 **銷毀**（此延遲天數可由服務"
+"若文件未儲存在任何雲端硬碟中，90 天後會從資料庫 **銷毀** （此延遲天數可由服務"
 "管理員設定）。"
 
 #: ../../user_guide/drive.rst:89
@@ -240,9 +235,8 @@ msgid "Drag the document from the drive into the |trash| **Trash**."
 msgstr "將文件從雲端硬碟拖曳到 |trash| **垃圾桶**。"
 
 #: ../../user_guide/drive.rst:92
-#, fuzzy
 msgid "``Right click`` > |trash| **Move to trash**"
-msgstr "按滑鼠右鍵 > |trash| **移到垃圾桶**"
+msgstr "``按滑鼠右鍵``  > |trash| **移到垃圾桶**"
 
 #: ../../user_guide/drive.rst:93
 msgid "Select the document and press the :kbd:`Del` key."
@@ -269,8 +263,8 @@ msgid ""
 "``Right click`` on the |trash| **Trash** tab to the left of the drive > "
 "|trash-o| **Empty the trash**."
 msgstr ""
-"在雲端硬碟左側的 |trash| **垃圾桶** 分頁上按滑鼠右鍵 > |trash-o| **清空垃圾"
-"桶**。"
+"在雲端硬碟左側的 |trash| **垃圾桶** 分頁上 ``按滑鼠右鍵`` > |trash-o| **清空"
+"垃圾桶**。"
 
 #: ../../user_guide/drive.rst:102
 msgid ""
@@ -285,19 +279,19 @@ msgid ""
 "**destroy** them."
 msgstr ""
 "清空垃圾桶時，若您是垃圾桶中部分文件的 :ref:`擁有者 <owners>`，系統會詢問您"
-"要**移除**還是**銷毀**這些文件。"
+"要 **移除** 還是 **銷毀** 這些文件。"
 
 #: ../../user_guide/drive.rst:106
 msgid "To **destroy** a document without storing it in the trash first:"
-msgstr "若要**銷毀**文件且不先放入垃圾桶："
+msgstr "若要 **銷毀** 文件且不先放入垃圾桶："
 
 #: ../../user_guide/drive.rst:108
 msgid ""
 "``Right click`` on the document in the drive > |cptools destroy| "
 "**Destroy**. :badge_owner:`Document owners`"
 msgstr ""
-"在雲端硬碟中的文件上按滑鼠右鍵 > |cptools destroy| **銷毀**。:badge_owner:`文"
-"件擁有者`"
+"在雲端硬碟中的文件上 ``按滑鼠右鍵`` > |cptools destroy| **銷"
+"毀**。:badge_owner:`文件擁有者`"
 
 #: ../../user_guide/drive.rst:111
 msgid ""
@@ -337,7 +331,7 @@ msgstr ""
 msgid ""
 "Restore the displayed version with |check| **Restore**, or exit the "
 "history without restoring with |times| **Close**."
-msgstr "以 |check| **還原**恢復顯示的版本，或以 |times| **關閉**離開歷程且不還原。"
+msgstr "以 |check| **還原** 恢復顯示的版本，或以 |times| **關閉** 離開歷程且不還原。"
 
 #: ../../user_guide/drive.rst:124
 msgid ""
@@ -372,16 +366,15 @@ msgstr "可用標籤將文件歸入多個分類。您的標籤不會被其他使
 msgid ""
 "The |hashtag| **Tags** tab in the drive displays all tags in use and "
 "their associated documents."
-msgstr "雲端硬碟中的 |hashtag| **標籤**分頁會顯示所有使用中的標籤及其對應文件。"
+msgstr "雲端硬碟中的 |hashtag| **標籤** 分頁會顯示所有使用中的標籤及其對應文件。"
 
 #: ../../user_guide/drive.rst:144
 msgid "To add or remove tags from a document:"
 msgstr "若要為文件新增或移除標籤："
 
 #: ../../user_guide/drive.rst:146
-#, fuzzy
 msgid "From the drive: ``Right click`` on the document > |hashtag| **Tags**."
-msgstr "在雲端硬碟中：在文件上按滑鼠右鍵 > |hashtag| **標籤**。"
+msgstr "在雲端硬碟中：在文件上按滑鼠右鍵 > |hashtag| **標籤** 。"
 
 #: ../../user_guide/drive.rst:147
 msgid "From a document: |file-o| **File** > |hashtag| **Tags**."
@@ -397,9 +390,8 @@ msgid "Select the documents with :kbd:`Ctrl` + ``Click`` in CryptDrive."
 msgstr "在 CryptDrive 中以 :kbd:`Ctrl` + 點選 選取多個文件。"
 
 #: ../../user_guide/drive.rst:152
-#, fuzzy
 msgid "``Right click`` on the documents > |hashtag| **Tags**."
-msgstr "在選取的文件上按滑鼠右鍵 > |hashtag| **標籤**。"
+msgstr "在選取的文件上 ``按滑鼠右鍵``  > |hashtag| **標籤**。"
 
 #: ../../user_guide/drive.rst:154
 msgid ""


### PR DESCRIPTION
Translations update from [CryptPad Translations](https://weblate.cryptpad.org) for [User guide/Main index](https://weblate.cryptpad.org/projects/user-guide/main-index/).



Current translation status:

![Weblate translation status](https://weblate.cryptpad.org/widget/user-guide/main-index/horizontal-auto.svg)