### PR TITLE
Rename to Euro-Office

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -73,7 +73,7 @@ If you encounter any issues, please check the :ref:`faq_common_issues` first. If
 Import/export is not visible in the File menu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For spreadsheets and advanced document processing, Cryptpad integrates OnlyOffice. As a result, there are two toolbars each with their own File menu on the same screen. Please make sure to check in both menus, when looking for import/export.
+For spreadsheets and advanced document processing, Cryptpad integrates Euro-Office. As a result, there are two toolbars each with their own File menu on the same screen. Please make sure to check in both menus, when looking for import/export.
 
 Document application import/export
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -183,10 +183,10 @@ The way encryption is currently used in CryptPad does not allow syncing with the
 
 .. _FAQ_OOintegration:
 
-What is the relationship between CryptPad and OnlyOffice?
+What is the relationship between CryptPad and Euro-Office?
 ---------------------------------------------------------
 
-The CryptPad :ref:`app_documents`, :ref:`app_presentation` & :ref:`app_sheets` applications are an `OnlyOffice Docs <https://www.onlyoffice.com/en/office-suite.aspx>`_ integration. However, this only concerns the client-side code, CryptPad does not make use of the OnlyOffice Document Server. CryptPad's encrypted collaboration, used for document, presentation & spreadsheets and other applications, is completely different from the encryption system used in parts of upstream OnlyOffice. Some of CryptPad's file format conversion tools are based on OnlyOffice code, but substantial work has been done to make it run in the browser rather than on the server, therefore avoiding the need to reveal the contents of users' documents when converting.
+The CryptPad :ref:`app_documents`, :ref:`app_presentation` & :ref:`app_sheets` applications are an `Euro-Office Docs <https://github.com/Euro-Office/>`_ integration. However, this only concerns the client-side code, CryptPad does not make use of the Euro-Office Document Server. CryptPad's encrypted collaboration, used for document, presentation & spreadsheets and other applications, is completely different from the encryption system used in parts of upstream Euro-Office. Some of CryptPad's file format conversion tools are based on Euro-Office code, but substantial work has been done to make it run in the browser rather than on the server, therefore avoiding the need to reveal the contents of users' documents when converting.
 
 How Secure is CryptPad?
 -----------------------

--- a/admin_guide/admin_panel.rst
+++ b/admin_guide/admin_panel.rst
@@ -123,7 +123,7 @@ Security
 Enable remote embedding
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Allow documents and media from this instance to be embedded on other websites. This will add an "Embed" option to the Share menu. For security reasons applications that use OnlyOffice (Sheets, Document, Presentation) cannot be embedded even if this setting is active.
+Allow documents and media from this instance to be embedded on other websites. This will add an "Embed" option to the Share menu. For security reasons applications that use Euro-Office (Sheets, Document, Presentation) cannot be embedded even if this setting is active.
 
 Please note that by enabling this settings, you will need to adapt your Nginx configuration file, adding ``vector:`` to pass :ref:`diagnostic tests <admin_checkup>`.
 

--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -83,18 +83,18 @@ Dependencies
    npm ci
    npm run install:components
 
-.. _admin_install_onlyoffice:
+.. _admin_install_eurooffice:
 
-OnlyOffice (optional)
+Euro-Office (optional)
 """""""""""""""""""""
 
-OnlyOffice applications (Spreadsheet, Document, and Presentation) are not bundled with CryptPad anymore. You can install/update OnlyOffice by running the installation script provided:
+Euro-Office applications (Spreadsheet, Document, and Presentation) are not bundled with CryptPad anymore. You can install/update Euro-Office by running the installation script provided:
 
 .. code:: bash
 
    ./install-office.sh
 
-If you can not or do not want to use this script, it is also possible to :ref:`install OnlyOffice manually <admin_install_onlyoffice_manually>`.
+If you can not or do not want to use this script, it is also possible to :ref:`install Euro-Office manually <admin_install_eurooffice_manually>`.
 
 Configuration
 """""""""""""
@@ -240,12 +240,12 @@ Note that you'll still need to follow the CryptPad configuration steps, especial
       - ./onlyoffice-conf:/cryptpad/onlyoffice-conf
       - ./config/config.js:/cryptpad/config/config.js
 
-.. _admin_install_onlyoffice_manually:
+.. _admin_install_eurooffice_manually:
 
-Install OnlyOffice manually
+Install Euro-Office manually
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is easier to use the :ref:`script <admin_install_onlyoffice>` to install OnlyOffice. However, it is also possible to install OnlyOffice manually.
+It is easier to use the :ref:`script <admin_install_eurooffice>` to install Euro-Office. However, it is also possible to install Euro-Office manually.
 
 For the first installation you need to clone `onlyoffice-builds` into your `cryptpad` folder:
 

--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -92,7 +92,7 @@ OnlyOffice applications (Spreadsheet, Document, and Presentation) are not bundle
 
 .. code:: bash
 
-   ./install-onlyoffice.sh
+   ./install-office.sh
 
 If you can not or do not want to use this script, it is also possible to :ref:`install OnlyOffice manually <admin_install_onlyoffice_manually>`.
 

--- a/admin_guide/maintenance.rst
+++ b/admin_guide/maintenance.rst
@@ -10,7 +10,7 @@ If OnlyOffice is installed, it also needs to be upgraded:
 
 .. code:: bash
 
-   ./install-onlyoffice.sh
+   ./install-office.sh
 
 .. note::
     If you are upgrading from an oldest release than the latest one, please read the upgrade notes of all versions between yours and the previous ones to avoid configuration issues (e.g. you are on 5.5.0 and want to upgrade to 2024.3.0, you'll need to upgrade to 5.6.0 and 5.7.0 before)

--- a/admin_guide/maintenance.rst
+++ b/admin_guide/maintenance.rst
@@ -6,7 +6,7 @@ Upgrading CryptPad
 
 To upgrade your CryptPad instance, please follow the indications provided in the Upgrade notes section of the `releases published on GitHub <https://github.com/cryptpad/cryptpad/releases>`__.
 
-If OnlyOffice is installed, it also needs to be upgraded:
+If Euro-Office is installed, it also needs to be upgraded:
 
 .. code:: bash
 

--- a/user_guide/apps/document.rst
+++ b/user_guide/apps/document.rst
@@ -3,7 +3,7 @@
 Document
 ========
 
-The Document application in CryptPad is an integration of `OnlyOffice <https://www.onlyoffice.com/>`__. To read more about the details of this integration see :ref:`FAQ_OOintegration`
+The Document application in CryptPad is an integration of `Euro-Office <https://github.com/Euro-Office/>`__. To read more about the details of this integration see :ref:`FAQ_OOintegration`
 
 .. image:: /images/app-document-preview.png
    :class: screenshot
@@ -20,10 +20,10 @@ Please refer to the `OnlyOffice documentation <https://helpcenter.onlyoffice.com
 Toolbars
 --------
 
-CryptPad integrates OnlyOffice documents into the same encrypted collaboration system as the other applications. Additionally OnlyOffice provides a wide range of functions in a tabbed toolbar. This results in a double toolbar that can cause confusion:
+CryptPad integrates Euro-Office documents into the same encrypted collaboration system as the other applications. Additionally Euro-Office provides a wide range of functions in a tabbed toolbar. This results in a double toolbar that can cause confusion:
 
 - The topmost **CryptPad toolbar** is used for |file-o| **File** operations (including import/export, history, properties, etc) as well as |share-alt| **Share** and |unlock-alt| **Access**.
-- The **OnlyOffice toolbar** is used for all functionality within the document itself, as well as the collaboration modes explained in the next section.
+- The **Euro-Office toolbar** is used for all functionality within the document itself, as well as the collaboration modes explained in the next section.
 
 Undo and collaboration modes
 ----------------------------
@@ -31,14 +31,14 @@ Undo and collaboration modes
 .. image:: /images/app-document-collab-mode.png
    :class: screenshot
 
-OnlyOffice provides two collaborative editing modes in documents that affect how changes are synced between users and whether or not the **Undo** functionality is available.
+Euro-Office provides two collaborative editing modes in documents that affect how changes are synced between users and whether or not the **Undo** functionality is available.
 
 - **Fast Mode** is enabled by default. New edits by all users are automatically synced with others as they are made. In this mode it is not possible to undo.
 - **Strict Mode** allows each user to make changes independently. The modified cells are "locked" for others until the author manually saves their changes. New edits are only synced with other users after being saved. In this mode it is possible to undo changes that have not yet been saved. When a user saves their changes, others are prompted to save in order to receive the latest edits.
 
 When :kbd:`Ctrl + Z` is pressed for undo, the application will automatically suggest switching to **Strict Mode** to enable the undo functionality.
 
-To switch back to **Fast mode** use the **Collaboration** tab in the OnlyOffice toolbar and select **Co-editing Mode** > **Fast**.
+To switch back to **Fast mode** use the **Collaboration** tab in the Euro-Office toolbar and select **Co-editing Mode** > **Fast**.
 
 .. note::
    CryptPad remembers your choice of editing mode on each device for all documents.
@@ -50,7 +50,7 @@ History
 
 To access the document history, use |file-o| **File** > |history| **History** in the CryptPad toolbar.
 
-Due to the integration of OnlyOffice with CryptPad's encrypted real-time collaboration, history in documents works differently than :ref:`in the other applications <document_history>`.
+Due to the integration of Euro-Office with CryptPad's encrypted real-time collaboration, history in documents works differently than :ref:`in the other applications <document_history>`.
 
 .. figure:: /images/history-toolbar-document.png
    :class: screenshot

--- a/user_guide/apps/general.rst
+++ b/user_guide/apps/general.rst
@@ -92,7 +92,7 @@ The history of documents is saved and can be restored if needed. To view and res
 To save storage space, history can be deleted in the document’s :ref:`properties <document_properties>` :badge_owner:`Document owners`
 
 .. note::
-   The history functionality works slightly differently in the :ref:`app_sheets` application, due to the integration of OnlyOffice with CryptPad's encrypted real-time collaboration. Please refer to :ref:`spreadsheet history <sheets_history>` for further details.
+   The history functionality works slightly differently in the :ref:`app_sheets` application, due to the integration of Euro-Office with CryptPad's encrypted real-time collaboration. Please refer to :ref:`spreadsheet history <sheets_history>` for further details.
 
 **Version Links**
 

--- a/user_guide/apps/presentation.rst
+++ b/user_guide/apps/presentation.rst
@@ -3,7 +3,7 @@
 Presentation
 ============
 
-The Presentation application in CryptPad is an integration of `OnlyOffice <https://www.onlyoffice.com/>`__. To read more about the details of this integration see :ref:`FAQ_OOintegration`
+The Presentation application in CryptPad is an integration of `Euro-Office <https://github.com/Euro-Office/>`__. To read more about the details of this integration see :ref:`FAQ_OOintegration`
 
 .. image:: /images/app-presentation-preview.png
    :class: screenshot
@@ -20,10 +20,10 @@ Please refer to the `OnlyOffice documentation <hhttps://helpcenter.onlyoffice.co
 Toolbars
 --------
 
-CryptPad integrates OnlyOffice presentations into the same encrypted collaboration system as the other applications. Additionally OnlyOffice provides a wide range of functions in a tabbed toolbar. This results in a double toolbar that can cause confusion:
+CryptPad integrates Euro-Office presentations into the same encrypted collaboration system as the other applications. Additionally Euro-Office provides a wide range of functions in a tabbed toolbar. This results in a double toolbar that can cause confusion:
 
 - The topmost **CryptPad toolbar** is used for |file-o| **File** operations (including import/export, history, properties, etc) as well as |share-alt| **Share** and |unlock-alt| **Access**.
-- The **OnlyOffice toolbar** is used for all functionality within the presentation document itself, as well as the collaboration modes explained in the next section.
+- The **Euro-Office toolbar** is used for all functionality within the presentation document itself, as well as the collaboration modes explained in the next section.
 
 Undo and collaboration modes
 ----------------------------
@@ -31,14 +31,14 @@ Undo and collaboration modes
 .. image:: /images/app-presentation-collab-mode.png
    :class: screenshot
 
-OnlyOffice provides two collaborative editing modes in presentations that affect how changes are synced between users and whether or not the **Undo** functionality is available.
+Euro-Office provides two collaborative editing modes in presentations that affect how changes are synced between users and whether or not the **Undo** functionality is available.
 
 - **Fast Mode** is enabled by default. New edits by all users are automatically synced with others as they are made. In this mode it is not possible to undo.
 - **Strict Mode** allows each user to make changes independently. The modified cells are "locked" for others until the author manually saves their changes. New edits are only synced with other users after being saved. In this mode it is possible to undo changes that have not yet been saved. When a user saves their changes, others are prompted to save in order to receive the latest edits.
 
 When :kbd:`Ctrl + Z` is pressed for undo, the application will automatically suggest switching to **Strict Mode** to enable the undo functionality.
 
-To switch back to **Fast mode** use the **Collaboration** tab in the OnlyOffice toolbar and select **Co-editing Mode** > **Fast**.
+To switch back to **Fast mode** use the **Collaboration** tab in the Euro-Office toolbar and select **Co-editing Mode** > **Fast**.
 
 .. note::
    CryptPad remembers your choice of editing mode on each device for all documents.
@@ -50,7 +50,7 @@ History
 
 To access the presentation history, use |file-o| **File** > |history| **History** in the CryptPad toolbar.
 
-Due to the integration of OnlyOffice with CryptPad's encrypted real-time collaboration, history in presentations works differently than :ref:`in the other applications <document_history>`.
+Due to the integration of Euro-Office with CryptPad's encrypted real-time collaboration, history in presentations works differently than :ref:`in the other applications <document_history>`.
 
 .. figure:: /images/history-toolbar-presentation.png
    :class: screenshot

--- a/user_guide/apps/sheets.rst
+++ b/user_guide/apps/sheets.rst
@@ -3,7 +3,7 @@
 Spreadsheet
 ===========
 
-The Spreadsheet application in CryptPad is an integration of `OnlyOffice <https://www.onlyoffice.com/>`__. To read more about the details of this integration see :ref:`FAQ_OOintegration`
+The Spreadsheet application in CryptPad is an integration of `Euro-Office <https://github.com/Euro-Office/>`__. To read more about the details of this integration see :ref:`FAQ_OOintegration`
 
 .. image:: /images/app-sheets-preview.png
    :class: screenshot
@@ -20,10 +20,10 @@ Please refer to the `OnlyOffice documentation <https://helpcenter.onlyoffice.com
 Toolbars
 --------
 
-CryptPad integrates OnlyOffice spreadsheets into the same encrypted collaboration system as the other applications. Additionally OnlyOffice provides a wide range of functions in a tabbed toolbar. This results in a double toolbar that can cause confusion:
+CryptPad integrates Euro-Office spreadsheets into the same encrypted collaboration system as the other applications. Additionally Euro-Office provides a wide range of functions in a tabbed toolbar. This results in a double toolbar that can cause confusion:
 
 - The topmost **CryptPad toolbar** is used for |file-o| **File** operations (including import/export, history, properties, etc) as well as |share-alt| **Share** and |unlock-alt| **Access**.
-- The **OnlyOffice toolbar** is used for all functionality within the spreadsheet document itself, as well as the collaboration modes explained in the next section.
+- The **Euro-Office toolbar** is used for all functionality within the spreadsheet document itself, as well as the collaboration modes explained in the next section.
 
 Undo and collaboration modes
 ----------------------------
@@ -31,14 +31,14 @@ Undo and collaboration modes
 .. image:: /images/app-sheets-collab-mode.png
    :class: screenshot
 
-OnlyOffice provides two collaborative editing modes in spreadsheets that affect how changes are synced between users and whether or not the **Undo** functionality is available.
+Euro-Office provides two collaborative editing modes in spreadsheets that affect how changes are synced between users and whether or not the **Undo** functionality is available.
 
 - **Fast Mode** is enabled by default. New edits by all users are automatically synced with others as they are made. In this mode it is not possible to undo.
 - **Strict Mode** allows each user to make changes independently. The modified cells are "locked" for others until the author manually saves their changes. New edits are only synced with other users after being saved. In this mode it is possible to undo changes that have not yet been saved. When a user saves their changes, others are prompted to save in order to receive the latest edits.
 
 When :kbd:`Ctrl + Z` is pressed for undo, the application will automatically suggest switching to **Strict Mode** to enable the undo functionality.
 
-To switch back to **Fast mode** use the **Collaboration** tab in the OnlyOffice toolbar and select **Co-editing Mode** > **Fast**.
+To switch back to **Fast mode** use the **Collaboration** tab in the Euro-Office toolbar and select **Co-editing Mode** > **Fast**.
 
 .. note::
    CryptPad remembers your choice of editing mode on each device for all documents.
@@ -50,7 +50,7 @@ History
 
 To access the spreadsheet history, use |file-o| **File** > |history| **History** in the CryptPad toolbar.
 
-Due to the integration of OnlyOffice with CryptPad's encrypted real-time collaboration, history in speadsheets works differently than :ref:`in the other applications <document_history>`.
+Due to the integration of Euro-Office with CryptPad's encrypted real-time collaboration, history in speadsheets works differently than :ref:`in the other applications <document_history>`.
 
 .. figure:: /images/history-toolbar-sheets.png
    :class: screenshot


### PR DESCRIPTION
* Update install-office.sh script name
* Rename OnlyOffice to Euro-Office

I did not rename OnlyOffice where it is used in links, that do not exist
on the Euro-Office side. E.g., links to the OnlyOffice documentation.